### PR TITLE
fix: Run /diag on all machines of the specified app_id

### DIFF
--- a/src/diagnostics/algolia-API-timing.js
+++ b/src/diagnostics/algolia-API-timing.js
@@ -15,8 +15,11 @@ function algoliaAPITiming(cb) {
   }
 
   var async = require('async');
+  var querystring = require('querystring');
 
-  var appId = 'latency';
+  var q = querystring.parse(document.location.search.slice(1));
+
+  var appId = (q.applicationId || 'latency').toLowerCase();
   var path = '/diag';
   var runs = 3;
   var subTitle = 'Timing %s (ms)';


### PR DESCRIPTION
I wanted to use the tool this morning to confirm that one server of an app cluster was down, but I figured out that it was always targeting the `latency` servers. The specified app id is actually only used to a a `search` at the end.

(At least now I know that I can just `curl https://appid-1.algolianet.com/diag` :) )