### PR TITLE
feat: Update index page to fetch params from query strings

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -135,5 +135,15 @@
     ga('create', 'UA-32446386-7', 'auto');
     ga('send', 'pageview');
   </script>
+  <script>
+    const formParameters = ['applicationId','apiKey','indexName']
+    let params = (new URL(document.location)).searchParams;
+
+    for (const idx in formParameters){
+      if (params.has(formParameters[idx])){
+        document.getElementById(formParameters[idx]).value = params.get(formParameters[idx])
+      }
+    }
+  </script>
 </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -135,15 +135,5 @@
     ga('create', 'UA-32446386-7', 'auto');
     ga('send', 'pageview');
   </script>
-  <script>
-    const formParameters = ['applicationId','apiKey','indexName']
-    let params = (new URL(document.location)).searchParams;
-
-    for (const idx in formParameters){
-      if (params.has(formParameters[idx])){
-        document.getElementById(formParameters[idx]).value = params.get(formParameters[idx])
-      }
-    }
-  </script>
 </body>
 </html>

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -2,4 +2,17 @@ module.exports = home;
 
 function home() {
   $('input[name="t"]').val(Date.now());
+  prefillAdvancedOptions();
+
 }
+
+function prefillAdvancedOptions() {
+  var formParameters = ['applicationId', 'apiKey', 'indexName'];
+  var params = new URL(document.location).searchParams;
+
+  for (var idx in formParameters){
+    if (params.has(formParameters[idx])){
+      document.getElementById(formParameters[idx]).value = params.get(formParameters[idx]);
+    }
+  }
+ }


### PR DESCRIPTION
I want to use this diag page in a troubleshooting process of browser connectivity issues, and it would be useful if we could share the URL with the advanced parameters prefilled by query strings.