### PR TITLE
feat: Update Algolia healthcheck URL from /diag to /1/isalive

### DIFF
--- a/src/diagnostics/algolia-API-timing.js
+++ b/src/diagnostics/algolia-API-timing.js
@@ -20,7 +20,7 @@ function algoliaAPITiming(cb) {
   var q = querystring.parse(document.location.search.slice(1));
 
   var appId = (q.applicationId || 'latency').toLowerCase();
-  var path = '/diag';
+  var path = '/1/isalive';
   var runs = 3;
   var subTitle = 'Timing %s (ms)';
 


### PR DESCRIPTION
Updated URL used in the algolia-API-timing test from `/diag` to `/1/isalive` which has better availability.