### PR TITLE
Replace mailto support link with Algolia support portal and fix clipboard copy

### DIFF
--- a/src/views/result.ts
+++ b/src/views/result.ts
@@ -1,5 +1,5 @@
 import { el } from '../lib/dom';
-import { copyIcon, sendIcon } from '../lib/icons';
+import { copyIcon } from '../lib/icons';
 
 export function renderResult(app: HTMLElement, output: string): void {
   const out = el('textarea', {
@@ -9,16 +9,14 @@ export function renderResult(app: HTMLElement, output: string): void {
   });
   out.value = output;
 
-  const send = el(
+  const support = el(
     'a',
-    { id: 'send', class: 'btn btn--default btn--sm', role: 'button' },
-    sendIcon(),
-    el('span', {}, 'Send'),
+    { id: 'send', class: 'link', role: 'button' },
+    'contact Algolia support',
   );
-  send.href =
-    'mailto:support@algolia.com' +
-    `?subject=${encodeURIComponent('diagnostic results')}` +
-    `&body=${encodeURIComponent(output)}`;
+  support.href = 'https://support.algolia.com/';
+  support.target = '_blank';
+  support.rel = 'noopener noreferrer';
 
   const copyLabel = el('span', {}, 'Copy');
   const copy = el(
@@ -48,9 +46,9 @@ export function renderResult(app: HTMLElement, output: string): void {
       'p',
       { class: 'alert alert--success' },
       el('strong', {}, 'Success!'),
-      ' ',
-      send,
-      ' us the results or ',
+      ' Copy the results and ',
+      support,
+      ' or ',
       el('a', { href: '?', class: 'link', role: 'button' }, 'start again'),
     ),
     el(


### PR DESCRIPTION
## Summary
- Replace the `mailto:support@algolia.com` send button with a link to the Algolia support portal (https://support.algolia.com/)
- Fix clipboard copy by replacing deprecated ZeroClipboard with the native Clipboard API
- Copy copies only highlighted output text; Select all highlights everything first
- Fix duplicate `#done` element IDs on the run and result pages

## Test plan
- [x] Run diagnostic to completion on the results page
- [x] Verify **contact Algolia support** opens https://support.algolia.com/ in a new tab
- [x] Verify **Select all** highlights all output text
- [x] Verify **Copy** copies only the highlighted selection
- [x] Verify **start again** reloads the diagnostic